### PR TITLE
Nimbora: separate calculations per token and trove

### DIFF
--- a/nimbora/borrow/tokens.json
+++ b/nimbora/borrow/tokens.json
@@ -7,10 +7,24 @@
         "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
     },
     {
+        "name": "LUSD Stablecoin",
+        "symbol": "LUSD",
+        "decimals": 18,
+        "trove": "0xEF3cf0ede2cA738A8Bd0c38fd5D43DC639B41532",
+        "address": "0x070a76fd48ca0ef910631754d77dd822147fe98a569b826ec85e3c33fde586ac"
+    },
+    {
         "name": "ETH",
         "symbol": "ETH",
         "decimals": 18,
         "trove": "0x4cdB2fdE85Da92Dbe9b568dda2Cc22d426b0b642",
         "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+    },
+    {
+        "name": "LUSD Stablecoin",
+        "symbol": "LUSD",
+        "decimals": 18,
+        "trove": "0x4cdB2fdE85Da92Dbe9b568dda2Cc22d426b0b642",
+        "address": "0x070a76fd48ca0ef910631754d77dd822147fe98a569b826ec85e3c33fde586ac"
     }
 ]


### PR DESCRIPTION
### Description 
OBL requested that we separate the supply and borrow per token.
```
ok since this is a per asset table can you please do a new PR where your final output is one asset per row -and per strategy in your case- (so for eth borrow would be 0) and then another row for lusd with all its info and supply zero but borrow that amount?
```