### PR TITLE
feat(zkLend): consider price of each stablecoin for STB row

### DIFF
--- a/zklend/function.py
+++ b/zklend/function.py
@@ -11,6 +11,7 @@ from starknet_py.net.full_node_client import FullNodeClient
 
 Z_TOKEN_ABI: List = json.load(open("./zklend/ztoken.abi.json"))
 MARKET_ABI: List = json.load(open("./zklend/market.abi.json"))
+PRAGMA_ADAPTER_ABI: List = json.load(open("./zklend/pragma_adapter.abi.json"))
 
 NODE_URL = "https://starknet-mainnet.public.blastapi.io"
 SUBGRAPH_URL = "https://hk-gateway.query.graph.zklend.com/subgraphs/name/zklend/web"
@@ -20,6 +21,8 @@ MARKET = "0x04c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05"
 PAGINATION_SIZE = 1000
 
 ACCUMULATOR_DECIMALS = 27
+# The number of decimal places used for USDT, USDC, and DAI at Pragma is all 8.
+PRAGMA_STABLECOIN_PRICE_DECIMALS = 8
 
 non_stables: List[Dict[str, Union[str, int]]] = [
     {
@@ -41,18 +44,21 @@ stables: List[Dict[str, Union[str, int]]] = [
         "token_decimals": 6,
         "underlying": "0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
         "z_token": "0x047ad51726d891f972e74e4ad858a261b43869f7126ce7436ee0b2529a98f486",
+        "pragma_price_adapter": "0x065354c0aefe9855866ef8f6215452a83dc3cebcf0100e22374c7da55f76f9b2",
     },
     {
         "symbol": "USDT",
         "token_decimals": 6,
         "underlying": "0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
         "z_token": "0x00811d8da5dc8a2206ea7fd0b28627c2d77280a515126e62baa4d78e22714c4a",
+        "pragma_price_adapter": "0x060f407449b26bc5e83461595e25dff3cca0733f654cd92a29bdd397d24e25bf",
     },
     {
         "symbol": "DAI",
         "token_decimals": 18,
         "underlying": "0x00da114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3",
         "z_token": "0x062fa7afe1ca2992f8d8015385a279f49fad36299754fb1e9866f4f052289376",
+        "pragma_price_adapter": "0x05d1bc06ca368cc451f63b20bc12bd2299a4ae7776f4dcf977723839bef311a0",
     },
 ]
 stable_symbols = [asset["symbol"] for asset in stables]
@@ -106,6 +112,18 @@ async def get_debt_accumulator(underlying_address: int, block_number: int) -> in
     )
     (uint_value,) = await contract.functions["get_debt_accumulator"].call(
         underlying_address, block_number=block_number
+    )
+    return uint_value
+
+
+async def get_pragma_price(adapter_address: int, block_number: int) -> int:
+    contract = Contract(
+        address=adapter_address,
+        abi=PRAGMA_ADAPTER_ABI,
+        provider=client,
+    )
+    (uint_value,) = await contract.functions["get_price"].call(
+        block_number=block_number
     )
     return uint_value
 
@@ -249,6 +267,7 @@ async def main():
         "lending_accumulator",
         "debt_accumulator",
         "token_decimals",
+        "decimal_price",
     ]
     cleaned = list(
         map(
@@ -278,6 +297,12 @@ async def get_data(asset, block_height):
     supply = await get_supply(z_token_int, block_height)
     debt = await get_debt(underlying_int, block_height)
 
+    decimal_price = None
+    if "pragma_price_adapter" in asset:
+        pragma_price_adapter_int = int(asset["pragma_price_adapter"], 16)
+        uint_raw_price = await get_pragma_price(pragma_price_adapter_int, block_height)
+        decimal_price = scale_down(uint_raw_price, PRAGMA_STABLECOIN_PRICE_DECIMALS)
+
     return {
         "protocol": "zkLend",
         "date": today,
@@ -295,6 +320,7 @@ async def get_data(asset, block_height):
         "lending_accumulator": lending_accumulator,
         "debt_accumulator": debt_accumulator,
         "token_decimals": asset["token_decimals"],
+        "decimal_price": decimal_price,
     }
 
 
@@ -304,10 +330,10 @@ def get_all_stables_data(assets, block_height):
     stables_debt = 0
 
     for asset in assets:
+        decimal_price = asset["decimal_price"]
+        lending_accumulator = asset["lending_accumulator"]
+        debt_accumulator = asset["debt_accumulator"]
         for user, balances in asset["raw_balance_per_user"].items():
-            lending_accumulator = asset["lending_accumulator"]
-            debt_accumulator = asset["debt_accumulator"]
-
             uint_face_value_supply = Decimal(balances["supply"]) * Decimal(
                 lending_accumulator
             )
@@ -321,19 +347,25 @@ def get_all_stables_data(assets, block_height):
             scaled_face_value_debt = scale_down(
                 face_value_debt, asset["token_decimals"]
             )
+            priced_scaled_face_value_supply = scaled_face_value_supply * decimal_price
+            priced_scaled_face_value_debt = scaled_face_value_debt * decimal_price
 
             if user in stables_raw_balance_per_user:
-                stables_raw_balance_per_user[user]["supply"] += scaled_face_value_supply
-                stables_raw_balance_per_user[user]["debt"] += scaled_face_value_debt
+                stables_raw_balance_per_user[user][
+                    "supply"
+                ] += priced_scaled_face_value_supply
+                stables_raw_balance_per_user[user][
+                    "debt"
+                ] += priced_scaled_face_value_debt
             else:
                 stables_raw_balance_per_user[user] = {
-                    "supply": scaled_face_value_supply,
-                    "debt": scaled_face_value_debt,
+                    "supply": priced_scaled_face_value_supply,
+                    "debt": priced_scaled_face_value_debt,
                 }
 
-        stables_supply += asset["supply_token"]
+        stables_supply += asset["supply_token"] * decimal_price
         # asset["borrow_token"] is already negative
-        stables_debt += asset["borrow_token"]
+        stables_debt += asset["borrow_token"] * decimal_price
 
     stables_total_non_recursive_supply = Decimal(0)
     for _, balances in stables_raw_balance_per_user.items():

--- a/zklend/pragma_adapter.abi.json
+++ b/zklend/pragma_adapter.abi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "inputs": [],
+    "name": "get_price",
+    "outputs": [
+      {
+        "name": "price",
+        "type": "felt"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
As per the discussion I just had with Gol, I am adding code to factor price information in for each asset in the last row that is used for STB. 

The latest price from Pragma for each stablecoin will be fetched and be multiplied with its supply and debt.

Example output with the current change:
[output_zklend.csv](https://github.com/delta-hq/openblocklabs-starknet-moneymarkets/files/14775364/output_zklend.csv)