### PR TITLE
update docs for btcfi

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For OpenBlock Labs (OBL) to compute scores for participating Starknet Money Market protocols, we are asking protocols to 
 provide code for calculations as described in the
-[Starknet Money Markets New Data Guidelines](https://docs.google.com/document/d/1uQddC1KB4lDLGWuTuGtWAxR11N1Nromz90rmgmpks1U/edit).
+[Starknet Money Markets New Data Guidelines](https://docs.google.com/document/d/12EbTqFgCppEtUX9TBe9hTxGtvFFWRS62bqjXzDpkXVE/edit?usp=sharing).
 
 This repository provides a framework for sharing your code with OBL. If you have any questions or comments about this 
 process, please contact us in our Telegram channel.


### PR DESCRIPTION
### TL;DR

Updated the link to the Starknet Money Markets New Data Guidelines document.

### What changed?

Changed the Google Docs link in the README.md file that points to the Starknet Money Markets New Data Guidelines. The old link was replaced with a new one that includes sharing permissions.

### How to test?

1. Click on the updated link in the README.md file
2. Verify that it opens the correct Starknet Money Markets New Data Guidelines document
3. Confirm you have proper access to the document

### Why make this change?

The previous document link may have been outdated or had restricted access. The new link includes sharing permissions (`usp=sharing` parameter) to ensure all protocol participants can access the guidelines document.